### PR TITLE
Handle symlinks when using 'cuckoo clean'

### DIFF
--- a/cuckoo/apps/apps.py
+++ b/cuckoo/apps/apps.py
@@ -411,6 +411,8 @@ def cuckoo_clean():
     for path in paths:
         if os.path.isdir(path):
             try:
+                # handle soft-links cases
+                path = os.path.realpath(path)
                 shutil.rmtree(path)
                 os.mkdir(path)
             except (IOError, OSError) as e:


### PR DESCRIPTION
##### What I have added/changed is:
One line of code.
- The real path of the directory (whether a regular dir or a soft link) is retrieved first and any files/directories will recursively be deleted afterwards.

##### The goal of my change is:
When using `$ cuckoo clean`, if one of the directories under `$CWD/storage/` is a soft-link, then an exception will be thrown and the files/directories that the soft-link points to will not be deleted.

##### What I have tested about my change is:
Before the change:
![image](https://user-images.githubusercontent.com/25797286/90157150-07910980-dd96-11ea-9e0c-29b772517274.png)


After the change:
![image](https://user-images.githubusercontent.com/25797286/90157045-e4fef080-dd95-11ea-84de-4067a9c1eaa7.png)

